### PR TITLE
Fix for pytest=9.1.0

### DIFF
--- a/src/idaes_flowsheet_processor/_testing/default_tests.py
+++ b/src/idaes_flowsheet_processor/_testing/default_tests.py
@@ -7,19 +7,22 @@ class TestFlowsheetInterface:
         assert isinstance(flowsheet_interface, FlowsheetInterface)
 
     @pytest.fixture(scope="class")
-    def interface_post_build(self, flowsheet_interface):
+    @classmethod
+    def interface_post_build(cls, flowsheet_interface):
         flowsheet_interface.build()
         return flowsheet_interface
 
     @pytest.fixture(scope="class")
-    def data(self, interface_post_build):
+    @classmethod
+    def data(cls, interface_post_build):
         return interface_post_build.dict()
 
     def test_data(self, data):
         assert len(data) > 0
 
     @pytest.fixture(scope="class")
-    def exports(self, data):
+    @classmethod
+    def exports(cls, data):
         return data.get("exports", None)
 
     def test_exports(self, exports):

--- a/src/idaes_flowsheet_processor/_testing/plugins.py
+++ b/src/idaes_flowsheet_processor/_testing/plugins.py
@@ -226,7 +226,8 @@ class IdaesFlowsheetsPlugin:
             )
 
     @pytest.fixture(scope="class")
-    def flowsheet_interface(self, request: pytest.FixtureRequest) -> FlowsheetInterface:
+    @classmethod
+    def flowsheet_interface(cls, request: pytest.FixtureRequest) -> FlowsheetInterface:
         module_name: str = request.param
         interface = FlowsheetInterface.from_module(module_name)
         return interface


### PR DESCRIPTION
The latest release of pytest is causing test failures in WaterTAP; see https://github.com/watertap-org/watertap/issues/1817

This PR applies the [guidance from pytest](https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method) for class-scoped fixtures to the flowsheet tests.

~I have been testing this fix on WaterTAP here: https://github.com/kurbansitterley/watertap/pull/18~ update: this fix works and is now a watertap PR: https://github.com/watertap-org/watertap/pull/1818