### PR TITLE
rename build_flowsheet to build

### DIFF
--- a/src/idaes_flowsheet_processor/tests/test_api.py
+++ b/src/idaes_flowsheet_processor/tests/test_api.py
@@ -54,7 +54,7 @@ class SOLVE_RESULT_OK:
 
 
 def build(build_options=None, **kwargs):
-    model = RO.build_flowsheet(erd_type=ERD_TYPE)
+    model = RO.main(erd_type=ERD_TYPE)
     return model
 
 

--- a/src/idaes_flowsheet_processor/tests/test_api.py
+++ b/src/idaes_flowsheet_processor/tests/test_api.py
@@ -53,7 +53,7 @@ class SOLVE_RESULT_OK:
     solver = SOLVE_STATUS
 
 
-def build_ro(build_options=None, **kwargs):
+def build(build_options=None, **kwargs):
     model = RO.build_flowsheet(erd_type=ERD_TYPE)
     return model
 
@@ -109,7 +109,7 @@ def flowsheet_interface(exports=True, solve_func=solve_ro):
         kwargs["do_export"] = export_to_ui
     return fsapi.FlowsheetInterface(
         # leave out name and description to test auto-fill
-        do_build=build_ro,
+        do_build=build,
         do_solve=solve_func,
         **kwargs,
     )
@@ -171,7 +171,7 @@ def test_actions(add_variant: str):
         nonlocal built
         built = True
         nonlocal m
-        m = build_ro()
+        m = build()
         return m
 
     def fake_solve(flowsheet=None):
@@ -227,7 +227,7 @@ def test_csv_exports():
             CSVTestSettings.bad_obj, CSVTestSettings.bad_units = False, False
         for export_func in (csv_from_tempfile, csv_from_localfile):
             fsi = fsapi.FlowsheetInterface(
-                do_build=build_ro, do_solve=solve_ro, do_export=export_func
+                do_build=build, do_solve=solve_ro, do_export=export_func
             )
             if i == 0:
                 fsi.build()  # expect success

--- a/src/idaes_flowsheet_processor/tests/test_api.py
+++ b/src/idaes_flowsheet_processor/tests/test_api.py
@@ -53,8 +53,8 @@ class SOLVE_RESULT_OK:
     solver = SOLVE_STATUS
 
 
-def build(build_options=None, **kwargs):
-    model = RO.main(erd_type=ERD_TYPE)
+def build_ro(build_options=None, **kwargs):
+    model = RO.build(erd_type=ERD_TYPE)
     return model
 
 
@@ -109,7 +109,7 @@ def flowsheet_interface(exports=True, solve_func=solve_ro):
         kwargs["do_export"] = export_to_ui
     return fsapi.FlowsheetInterface(
         # leave out name and description to test auto-fill
-        do_build=build,
+        do_build=build_ro,
         do_solve=solve_func,
         **kwargs,
     )
@@ -171,7 +171,7 @@ def test_actions(add_variant: str):
         nonlocal built
         built = True
         nonlocal m
-        m = build()
+        m = build_ro()
         return m
 
     def fake_solve(flowsheet=None):
@@ -227,7 +227,7 @@ def test_csv_exports():
             CSVTestSettings.bad_obj, CSVTestSettings.bad_units = False, False
         for export_func in (csv_from_tempfile, csv_from_localfile):
             fsi = fsapi.FlowsheetInterface(
-                do_build=build, do_solve=solve_ro, do_export=export_func
+                do_build=build_ro, do_solve=solve_ro, do_export=export_func
             )
             if i == 0:
                 fsi.build()  # expect success


### PR DESCRIPTION
test_api method build_flowsheet needs to be renamed to build due to change in watertap
https://github.com/watertap-org/watertap/commit/237ea007612c8c9e9a2865fa2ef81c81dbd0d471
